### PR TITLE
Fix key expiration ordering

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -201,7 +201,7 @@ class Redis
 
     def set_expiration_if_necessary
       if @expiration
-        [available_key, exists_key, version_key].each do |key|
+        [exists_key, available_key, version_key].each do |key|
           @redis.expire(key, @expiration)
         end
       end


### PR DESCRIPTION
Fix key expiration ordering. Make sure expiration is set first on exists key, so that it is first to expire. Otherwise, it is possible for new lock to start right as keys are expiring and catch it when available key has expired, but exists key has not, which will cause the new lock to block forever since there are no available resources and the lock is not re-initialized.

Testing

- [x] Run gem's tests
- [x] Manually test in console with Gemfile pointed to local code and ensure lock still works.