### PR TITLE
Fix key expiration ordering. 

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -201,7 +201,7 @@ class Redis
 
     def set_expiration_if_necessary
       if @expiration
-        [available_key, exists_key, version_key].each do |key|
+        [exists_key, available_key, version_key].each do |key|
           @redis.expire(key, @expiration)
         end
       end


### PR DESCRIPTION
Redis semaphore works by managing 4 Redis structures for a given semephore:
- The **exists** key acts as a boolean indicator for whether that key is being managed
- The **version** key holds the version of the API
- The **available** key is an array of grabbable tokens, whose length determines how many more workers can proceed before blocking kicks in (in our case, the array never has more than one element)
- The **grabbed** key is a hash, whose keys are the tokens that have been grabbed (indicating a worker has the semaphore), and whose values are the time at which the token was grabbed.

When a semaphore is initialized, the **available**, **exists** and **version** keys have an expiration set, importantly, **in that order.** When a key expires, this means it is deleted from Redis -- expiration has nothing to do with timing out the semaphore, but rather key cleanup.

The problem is, if a new invocation for a semaphore (of the same name) occurs right as the keys are expiring, it is possible for the available key to have expired and the exists key not to have, due to the order in which their expirations were set. This means the new invocations proceeds assuming the semaphore is in a good state, but in fact, the available list of tokens is empty (since that key was deleted), and it simply blocks forever. Furthermore, the expiration on the exists key is cleared during this process. It normally would be re-set when the the next worker released a token, but as no worker will ever release a token, the exists key will remain forever, and no future semaphore with the same name will ever re-initialize the keys.

So let's say a semaphore with the name "FOO" is created with an expiration of one minute, and then re-invoked one minute later. Here is what can happen.

- `FOO` semaphore initialized
- `SEMAPHORE:FOO:AVAILABLE` initialized w/ 1 minute expiration
- `SEMAPHORE:FOO:EXISTS` initialized w/ 1 minute expiration
- `SEMAPHORE:FOO:VERSION` initialized w/ 1 minute expiration
- `SEMAPHORE:FOO:GRABBED` initialized but deletes as soon as semaphore released
- 1 minute passes
- `SEMAPHORE:FOO:AVAILABLE` expires
- `FOO` semaphore invoked again before the other keys expire
- since `SEMAPHORE:FOO:EXISTS` still exists, it does not recreate the semaphore and instead tries to pop a token from `SEMAPHORE:FOO:AVAILABLE`. Since `SEMAPHORE:FOO:AVAILABLE` expired already, this process will now block indefinitely
- bad stuff happens

This PR simply changes the order in which the expirations are set, so that the exists key will expire before the available key. In the case above, this should mean that the lock is reinitialized rather than proceeding directly to trying to grab a token.

Testing

- [x] Run gem's tests
- [x] Manually test in console with Gemfile pointed to local code and ensure lock still works.
- [x] Manual hacking to artificially set a longer expiration on the exists key and kicking off a new semaphore in a different console after available key expires and before exists key expires to reproduce the problem. After flipping key order, unable to reproduce the problem in the same manner when kicking of new semaphore after exists key expires but before available key expires.